### PR TITLE
Add dataset_files table

### DIFF
--- a/init/001-ddl.sql
+++ b/init/001-ddl.sql
@@ -102,3 +102,15 @@ CREATE TABLE IF NOT EXISTS vdi.import_messages (
 , message VARCHAR
     NOT NULL
 );
+
+
+CREATE TABLE IF NOT EXISTS vdi.dataset_files (
+  dataset_id VARCHAR(32)
+    NOT NULL
+    REFERENCES vdi.datasets (dataset_id)
+, file_name VARCHAR
+    NOT NULL
+, file_size BIGINT
+    NOT NULL
+, CONSTRAINT file_uq UNIQUE (dataset_id, file_name)
+);

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ build:
 run:
 	@docker run -it --rm \
 		-p 5432:5432 \
-		-e POSTGRES_USER=postgres \
-		-e POSTGRES_PASSWORD=password \
+		-e POSTGRES_USER=someUser \
+		-e POSTGRES_PASSWORD=somePassword \
 		-e POSTGRES_DB=vdi \
 		veupathdb/vdi-internal-db:latest


### PR DESCRIPTION
To support the old user dataset UI feature of showing the dataset file count and total file size in the dataset list table, we need to track the files in the cache-db to avoid making many requests to MinIO per dataset-list request.